### PR TITLE
Quick fixe for new duplicate share attacks

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -510,6 +510,16 @@ function handleMinerMethod(method, params, ip, portData, sendReply, pushMessage)
             }
 
             params.nonce = params.nonce.substr(0, 8).toLowerCase();
+            var pattern = new RegExp("^[0-9A-Fa-f]+$");
+            if ( pattern.test(params.nonce) == false ) {
+                var minerText = miner ? (' ' + miner.login + '@' + miner.ip) : '';
+                log('warn', logSystem, 'Nonce Attack: ' + JSON.stringify(params) + ' from ' + minerText);
+                perIPStats[miner.ip] = { validShares: 0, invalidShares: 66666666 };
+                miner.checkBan(false);
+                sendReply('Duplicate share');
+                return;
+            }
+
 
             if (job.submissions.indexOf(params.nonce) !== -1){
                  var minerText = miner ? (' ' + miner.login + '@' + miner.ip) : '';


### PR DESCRIPTION
letter is replace per 0 , in function compute hash.
Attacker compute one share and resend nonce after replace one zero per letter .
